### PR TITLE
Issue #27 add module-creator role

### DIFF
--- a/cddl/concise-swid-tag.cddl
+++ b/cddl/concise-swid-tag.cddl
@@ -60,6 +60,7 @@ $role /= aggregator
 $role /= distributor
 $role /= licensor
 $role /= maintainer
+$role /= module-creator
 $role /= uint / text
 
 link-entry = {


### PR DESCRIPTION
Added $role for module creator. comid includes coswid roles in the concise module tag map.